### PR TITLE
Specify linux fpm platform so packages are always created properly (rebased)

### DIFF
--- a/dist/recipe.rb
+++ b/dist/recipe.rb
@@ -15,6 +15,8 @@ class GraylogSidecar < FPM::Cookery::Recipe
 
   config_files '/etc/graylog/collector-sidecar/collector_sidecar.yml'
 
+  fpm_attributes rpm_os: 'linux'
+
   def build
   end
 

--- a/dist/recipe32.rb
+++ b/dist/recipe32.rb
@@ -15,6 +15,8 @@ class GraylogSidecar < FPM::Cookery::Recipe
 
   config_files '/etc/graylog/collector-sidecar/collector_sidecar.yml'
 
+  fpm_attributes rpm_os: 'linux'
+
   def build
   end
 


### PR DESCRIPTION
Without this, RPM/DEBs are built for darwin when building on MacOS/OSX, resulting in `package collector-sidecar-0.0.9_cb1-1.x86_64 is intended for a darwin operating system` when installing.

This is a redo of #2 with a rebase from upstream so changes are clean.